### PR TITLE
Add HTML report generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.gradle/
+/build/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # testcasereporter
-Test case reporter in java
+
+Simple annotation based test case reporter using JUnit 5. Apply `@TestCases` on
+a test class to automatically register the reporter and provide Jira IDs for each
+test method. After execution an HTML report is written to `build/reports/test-cases.html`.
+The report generation can be disabled by running tests with the system property
+`-Dtestcases.report.enabled=false`.
+
+Usage example:
+
+```java
+@TestCases({"AUTH-1023", "AUTH-9999"})
+class SampleTest {
+
+    @Test
+    void shouldPassValidation() {
+        Assertions.assertTrue(true);
+    }
+
+    @Test
+    void shouldAlsoPass() {
+        Assertions.assertEquals(4, 2 + 2);
+    }
+}
+```
+
+Running the tests generates the HTML report with the Jira id and the status of
+each test.

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.junit.jupiter:junit-jupiter-api:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+}
+
+test {
+    useJUnitPlatform()
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'testcasereporter'

--- a/src/main/java/com/example/TestCases.java
+++ b/src/main/java/com/example/TestCases.java
@@ -1,0 +1,19 @@
+package com.example;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Class-level annotation to register test case IDs.
+ * The number of IDs must match the number of test methods in the class.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ExtendWith(TestCasesExtension.class)
+public @interface TestCases {
+    String[] value();
+}

--- a/src/main/java/com/example/TestCasesExtension.java
+++ b/src/main/java/com/example/TestCasesExtension.java
@@ -1,0 +1,128 @@
+package com.example;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+
+/**
+ * JUnit 5 extension that validates Jira-like IDs provided via {@link TestCases}
+ * and reports pass/fail status.
+ */
+public class TestCasesExtension implements TestWatcher, BeforeAllCallback, AfterAllCallback {
+
+    private static final Pattern JIRA_PATTERN = Pattern.compile("^[A-Z][A-Z0-9]+-\\d+$");
+
+    private static class Result {
+        final String id;
+        final String testName;
+        final String status;
+
+        Result(String id, String testName, String status) {
+            this.id = id;
+            this.testName = testName;
+            this.status = status;
+        }
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        Class<?> testClass = context.getRequiredTestClass();
+        TestCases annotation = testClass.getAnnotation(TestCases.class);
+        if (annotation == null) {
+            throw new IllegalStateException("@TestCases is required on class " + testClass.getName());
+        }
+        String[] ids = annotation.value();
+        long testMethodCount = Arrays.stream(testClass.getDeclaredMethods())
+                .filter(m -> m.isAnnotationPresent(Test.class))
+                .count();
+        if (ids.length != testMethodCount) {
+            throw new IllegalArgumentException("Expected " + testMethodCount + " ids but found " + ids.length);
+        }
+        for (String id : ids) {
+            validateId(id);
+        }
+        ExtensionContext.Store store = context.getStore(Namespace.create(TestCasesExtension.class, testClass));
+        store.put("ids", ids);
+        store.put("index", new AtomicInteger(0));
+        store.put("results", new ArrayList<Result>());
+    }
+
+    private String validateId(String id) {
+        if (!JIRA_PATTERN.matcher(id).matches()) {
+            throw new IllegalArgumentException("Invalid test case id: " + id);
+        }
+        return id;
+    }
+
+    private void record(ExtensionContext context, String status) {
+        ExtensionContext.Store store = context.getStore(Namespace.create(TestCasesExtension.class, context.getRequiredTestClass()));
+        String[] ids = store.get("ids", String[].class);
+        AtomicInteger idx = store.get("index", AtomicInteger.class);
+        List<Result> results = store.get("results", List.class);
+        int i = idx.getAndIncrement();
+        if (ids == null || i >= ids.length) {
+            throw new IllegalStateException("No ID available for test " + context.getDisplayName());
+        }
+        String id = ids[i];
+        results.add(new Result(id, context.getDisplayName(), status));
+    }
+
+    @Override
+    public void testSuccessful(ExtensionContext context) {
+        record(context, "PASSED");
+    }
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        record(context, "FAILED");
+    }
+
+    @Override
+    public void afterAll(ExtensionContext context) {
+        ExtensionContext.Store store = context.getStore(Namespace.create(TestCasesExtension.class, context.getRequiredTestClass()));
+        List<Result> results = store.get("results", List.class);
+        if (results == null || results.isEmpty()) {
+            return;
+        }
+
+        boolean enabled = Boolean.parseBoolean(System.getProperty("testcases.report.enabled", "true"));
+        if (!enabled) {
+            return;
+        }
+
+        try {
+            Path reportDir = Paths.get("build", "reports");
+            Files.createDirectories(reportDir);
+            Path output = reportDir.resolve("test-cases.html");
+            StringBuilder sb = new StringBuilder();
+            sb.append("<!DOCTYPE html><html><head><meta charset=\"UTF-8\"><title>TestCase Report</title></head><body>");
+            sb.append("<table border=\"1\"><tr><th>ID</th><th>Test</th><th>Status</th></tr>");
+            for (Result r : results) {
+                sb.append("<tr><td>")
+                  .append(r.id)
+                  .append("</td><td>")
+                  .append(r.testName)
+                  .append("</td><td>")
+                  .append(r.status)
+                  .append("</td></tr>");
+            }
+            sb.append("</table></body></html>");
+            Files.write(output, sb.toString().getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to write report", e);
+        }
+    }
+}

--- a/src/test/java/com/example/InvalidIdTest.java
+++ b/src/test/java/com/example/InvalidIdTest.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Assertions;
+
+@Disabled("Demonstrates invalid id failure")
+@TestCases({"invalid"})
+public class InvalidIdTest {
+
+    @Test
+    void invalidIdShouldThrow() {
+        IllegalArgumentException ex = Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Assertions.assertTrue(true);
+        });
+        Assertions.assertEquals("Invalid test case id: invalid", ex.getMessage());
+    }
+}

--- a/src/test/java/com/example/SampleTest.java
+++ b/src/test/java/com/example/SampleTest.java
@@ -1,0 +1,18 @@
+package com.example;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@TestCases({"AUTH-1023", "AUTH-9999"})
+public class SampleTest {
+
+    @Test
+    void shouldPassValidation() {
+        Assertions.assertTrue(true);
+    }
+
+    @Test
+    void shouldAlsoPass() {
+        Assertions.assertEquals(4, 2 + 2);
+    }
+}


### PR DESCRIPTION
## Summary
- write `test-cases.html` from `TestCasesExtension`
- document HTML output and disabling via system property

## Testing
- `gradle test --no-daemon --console=plain`

------
https://chatgpt.com/codex/tasks/task_e_6873b412f95c83309958a8f2690e2b26